### PR TITLE
Adapt to vty 5.x

### DIFF
--- a/vty-menu.cabal
+++ b/vty-menu.cabal
@@ -1,18 +1,18 @@
 Name: vty-menu
-Version: 0.0.3
+Version: 0.0.4
 Synopsis: A lib for displaying a menu and getting a selection using VTY
 Category:Graphics
 
 License: GPL-3
 License-file:COPYING 
-Author: Timothy Hobbs & Cheater__
+Author: Timothy Hobbs & Cheater__, Sergii Rudchenko <rudchenkos@gmail.com>
 Maintainer: Timothy Hobbs <timothyhobbs@seznam.cz>
 build-type:Simple
 
 cabal-version: >= 1.6
 
 library
- build-depends:base<5,vty <= 4.8
+ build-depends:base<5,vty >= 5 && < 6
  exposed-modules:Graphics.Vty.Menu
 
 Executable vty-menu

--- a/vty-menu.hs
+++ b/vty-menu.hs
@@ -1,0 +1,14 @@
+{- This executables sole purpose is getting arround  http://hackage.haskell.org/trac/ghc/ticket/7789 -}
+import Graphics.Vty.Menu
+import System.Environment
+import System.IO
+
+main = do
+ { args <- getArgs
+ ; ansM <- displayMenu args
+ ; let
+    ans =
+     case ansM of
+      Nothing -> ""
+      Just ans' -> ans'
+ ; hPutStrLn stderr ans }


### PR DESCRIPTION
Hi Timothy,

I noticed that vty-menu doesn't build against the current version of vty:

```
$ cabal install vty-menu
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: vty-menu-0.0.3 (user goal)
next goal: vty (dependency of vty-menu-0.0.3)
rejecting: vty-5.11.1/installed-972..., 5.11/installed-a71..., 5.11.1, 5.11,
5.10, 5.9.1, 5.9, 5.8.1, 5.8, 5.7.1, 5.7, 5.6, 5.5.0, 5.4.0, 5.3.1, 5.3,
5.2.11, 5.2.10, 5.2.9, 5.2.8, 5.2.7, 5.2.6, 5.2.5, 5.2.4, 5.2.3, 5.2.2, 5.2.1,
5.2.0, 5.1.4, 5.1.3, 5.1.1, 5.1.0, 5.0.2, 5.0.1, 5.0.0 (conflict: vty-menu =>
vty<=4.8)
trying: vty-4.7.5
trying: string-qq-0.0.2 (dependency of vty-4.7.5)
trying: template-haskell-2.10.0.0/installed-3c4... (dependency of
string-qq-0.0.2)
next goal: pretty (dependency of template-haskell-2.10.0.0/installed-3c4...)
rejecting: pretty-1.1.2.0/installed-5cc... (conflict: pretty =>
deepseq==1.4.1.1/installed-614..., vty => deepseq>=1.1 && <1.4)
rejecting: pretty-1.1.3.4, 1.1.3.3, 1.1.3.2, 1.1.3.1, 1.1.2.1, 1.1.2.0,
1.1.1.3, 1.1.1.2, 1.1.1.1, 1.1.1.0, 1.1.0.0, 1.0.1.2, 1.0.1.1, 1.0.1.0,
1.0.0.0 (conflict: template-haskell => pretty==1.1.2.0/installed-5cc...)
Backjump limit reached (change with --max-backjumps).
```

So I've made minimal changes to make it work with vty 5 (tested on 5.11).
Also, I have added `vty-menu.hs` which was missing on GitHub.

Please update the package on Hackage so we can all enjoy the power of terminal menus :)
